### PR TITLE
Fe/frontend idle timer

### DIFF
--- a/friends_app/static/css/styles.css
+++ b/friends_app/static/css/styles.css
@@ -75,6 +75,14 @@ body {
     transform: scale(1.1);
 }
 
+.pulse {
+    animation: pulse 3s infinite;
+    -webkit-animation: pulse 3s infinite;
+    -moz-animation: pulse 3s infinite;
+    -ms-animation: pulse 3s infinite;
+    -o-animation: pulse 3s infinite;
+}
+
 .btn-switch {
     font-family: 'Permanent Marker', cursive;
     font-size: 30px;
@@ -133,6 +141,7 @@ body {
     box-shadow: 0px 0px 10px 5px rgba(0,0,0,0.66);
 }
 
+/* color transition on hover */
 @-webkit-keyframes color-change {
     0% { color: #E91D24; }
     20% { color: #01B2E7; }
@@ -173,3 +182,34 @@ body {
     80% { color: #FABC17; }
     100% { color: #01B2E7; }
 }
+
+/* pulsating logo after being idle */
+@-webkit-keyframes pulse {
+    0% { -webkit-transform: scale(1); }
+    50% { -webkit-transform: scale(1.2); }
+    100% { -webkit-transform: scale(1); }
+ }
+
+ @-moz-keyframes pulse {
+    0% { -webkit-transform: scale(1); }
+    50% { -webkit-transform: scale(1.2); }
+    100% { -webkit-transform: scale(1); }
+ }
+
+ @-ms-keyframes pulse {
+    0% { -webkit-transform: scale(1); }
+    50% { -webkit-transform: scale(1.2); }
+    100% { -webkit-transform: scale(1); }
+ }
+
+ @-o-keyframes pulse {
+    0% { -webkit-transform: scale(1); }
+    50% { -webkit-transform: scale(1.2); }
+    100% { -webkit-transform: scale(1); }
+ }
+
+ @keyframes pulse {
+    0% { -webkit-transform: scale(1); }
+    50% { -webkit-transform: scale(1.2); }
+    100% { -webkit-transform: scale(1); }
+ }

--- a/friends_app/static/js/coolScript.js
+++ b/friends_app/static/js/coolScript.js
@@ -42,7 +42,6 @@ var idleTime = function() {
     function resetIdleTime() {
         clearTimeout(time);
         $('#friends-logo-image').removeClass('pulse')
-        console.log('reset')
         time = setTimeout(pulsateLogo, 30000)
     }
 }

--- a/friends_app/static/js/coolScript.js
+++ b/friends_app/static/js/coolScript.js
@@ -1,10 +1,11 @@
 $(document).ready(function() {
+    idleTime();
     $('.hidden').animate({'opacity': 1}, 3000);
     $('.btn-switch').animate({'opacity': 1}, 3000);
 });
 
 getNewEpisode = () => {
-    window.location.reload()
+    window.location.reload();
 }
 
 changeDisplay = () => {
@@ -26,4 +27,22 @@ showMessage = () => {
     $(".details").animate({'opacity': 0}, 1000);
     $('.hidden').animate({'opacity': 1}, 1000);
     document.getElementsByClassName("btn-switch")[0].innerHTML = "Tell me more!";
+}
+
+var idleTime = function() {
+    var time;
+    window.onload = resetIdleTime;
+    document.onmousemove = resetIdleTime;
+    document.onkeypress = resetIdleTime;
+
+    function pulsateLogo() {
+        $('#friends-logo-image').addClass('pulse')
+        }
+
+    function resetIdleTime() {
+        clearTimeout(time);
+        $('#friends-logo-image').removeClass('pulse')
+        console.log('reset')
+        time = setTimeout(pulsateLogo, 30000)
+    }
 }


### PR DESCRIPTION
The FRIENDS logo will now start pulsating if the user remains idle for at least 30 seconds, indicating that it can be clicked in order to refresh the page. Timer resets on keydown and mousemove events. Additionaly, some code cleanup was made in the JS script.